### PR TITLE
add missing models and reformat model selection as table

### DIFF
--- a/README.md
+++ b/README.md
@@ -58,10 +58,10 @@ You can choose between models based on your needs.
 
 | Model           | Size   | Pros                       | Cons                                   | Public Model |
 |-----------------|--------|----------------------------|----------------------------------------|--------------|
-| **TinyBERT**    | 57.1 MB  | Very small,<br>fast        | Lower accuracy<br>than larger models   | [atjsh/llmlingua-2-js-tinybert-meetingbank](https://huggingface.co/atjsh/llmlingua-2-js-tinybert-meetingbank) |
-| **MobileBERT**  | 99.2 MB  | Small,<br>optimized for mobile | Moderate accuracy,<br>tradeoff in depth | [atjsh/llmlingua-2-js-mobilebert-meetingbank](https://huggingface.co/atjsh/llmlingua-2-js-mobilebert-meetingbank) |
-| **BERT**        | 710 MB   | Faster,<br>smaller size    | Lower accuracy<br>than XLM-RoBERTa     | [Arcoldd/llmlingua4j-bert-base-onnx](https://huggingface.co/Arcoldd/llmlingua4j-bert-base-onnx) |
-| **XLM-RoBERTa** | 2240 MB  | High accuracy              | Slower,<br>slightly larger in size     | [atjsh/llmlingua-2-js-xlm-roberta-large-meetingbank](https://huggingface.co/atjsh/llmlingua-2-js-xlm-roberta-large-meetingbank) |
+| **TinyBERT**    | [57.1 MB](https://huggingface.co/atjsh/llmlingua-2-js-tinybert-meetingbank/blob/main/onnx/model.onnx)  | Very small,<br>fast        | Lower accuracy<br>than larger models   | [atjsh/llmlingua-2-js-tinybert-meetingbank](https://huggingface.co/atjsh/llmlingua-2-js-tinybert-meetingbank) |
+| **MobileBERT**  | [99.2 MB](https://huggingface.co/atjsh/llmlingua-2-js-mobilebert-meetingbank/blob/main/onnx/model.onnx)  | Small,<br>optimized for mobile | Moderate accuracy,<br>tradeoff in depth | [atjsh/llmlingua-2-js-mobilebert-meetingbank](https://huggingface.co/atjsh/llmlingua-2-js-mobilebert-meetingbank) |
+| **BERT**        | [710 MB](https://huggingface.co/Arcoldd/llmlingua4j-bert-base-onnx/blob/main/model.onnx)   | Faster,<br>smaller size    | Lower accuracy<br>than XLM-RoBERTa     | [Arcoldd/llmlingua4j-bert-base-onnx](https://huggingface.co/Arcoldd/llmlingua4j-bert-base-onnx) |
+| **XLM-RoBERTa** | [2240 MB](https://huggingface.co/atjsh/llmlingua-2-js-xlm-roberta-large-meetingbank/blob/main/onnx/model.onnx_data)  | High accuracy              | Slower,<br>slightly larger in size     | [atjsh/llmlingua-2-js-xlm-roberta-large-meetingbank](https://huggingface.co/atjsh/llmlingua-2-js-xlm-roberta-large-meetingbank) |
 
 [Learn More](https://llmlingua.com/llmlingua2.html#:~:text=our%20classification%20model.-,Performance,-We%20evaluate%20LLMLingua) about the performance of each model (actual performance may vary).
 

--- a/README.md
+++ b/README.md
@@ -56,14 +56,12 @@ npm install @atjsh/llmlingua-2
 
 You can choose between models based on your needs.
 
-1. **XLM-RoBERTa**
-   - Pros: High accuracy
-   - Cons: Slower, and slightly larger in size
-   - Public Model: **[atjsh/llmlingua-2-js-xlm-roberta-large-meetingbank](https://huggingface.co/atjsh/llmlingua-2-js-xlm-roberta-large-meetingbank)**
-2. **BERT**
-   - Pros: Faster, smaller in size
-   - Cons: Lower accuracy compared to XLM-RoBERTa
-   - Public Model: **[Arcoldd/llmlingua4j-bert-base-onnx](https://huggingface.co/Arcoldd/llmlingua4j-bert-base-onnx)**
+| Model           | Size   | Pros                       | Cons                                   | Public Model |
+|-----------------|--------|----------------------------|----------------------------------------|--------------|
+| **TinyBERT**    | 57.1 MB  | Very small,<br>fast        | Lower accuracy<br>than larger models   | [atjsh/llmlingua-2-js-tinybert-meetingbank](https://huggingface.co/atjsh/llmlingua-2-js-tinybert-meetingbank) |
+| **MobileBERT**  | 99.2 MB  | Small,<br>optimized for mobile | Moderate accuracy,<br>tradeoff in depth | [atjsh/llmlingua-2-js-mobilebert-meetingbank](https://huggingface.co/atjsh/llmlingua-2-js-mobilebert-meetingbank) |
+| **BERT**        | 710 MB   | Faster,<br>smaller size    | Lower accuracy<br>than XLM-RoBERTa     | [Arcoldd/llmlingua4j-bert-base-onnx](https://huggingface.co/Arcoldd/llmlingua4j-bert-base-onnx) |
+| **XLM-RoBERTa** | 2240 MB  | High accuracy              | Slower,<br>slightly larger in size     | [atjsh/llmlingua-2-js-xlm-roberta-large-meetingbank](https://huggingface.co/atjsh/llmlingua-2-js-xlm-roberta-large-meetingbank) |
 
 [Learn More](https://llmlingua.com/llmlingua2.html#:~:text=our%20classification%20model.-,Performance,-We%20evaluate%20LLMLingua) about the performance of each model (actual performance may vary).
 


### PR DESCRIPTION
Thanks for your work porting the original code to TS!

* I added two other models that you have since added to the [demo](https://atjsh.github.io/llmlingua-2-js/) but are missing from the README.

* I felt it would be nice to include the average download size of each model so I added it. In fact, I went ahead and reformatted that section to be easier to scan so I redid it into a table.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Reworked the Model Selection section from a short list into a comparison table for easier scanning.
  * Added TinyBERT and MobileBERT; retained BERT and XLM-RoBERTa with updated descriptions.
  * Each model now shows size, pros, cons, and a public model link.
  * Preserved the existing "Learn More" link.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->