### PR TITLE
feat: replace js-tiktoken with @huggingface/tokenizers (GH-33)

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -2,6 +2,12 @@ name: Publish
 
 on:
   workflow_dispatch:
+    inputs:
+      dist-tag:
+        description: "npm dist-tag. Use 'latest' only for the newest major line; use e.g. 'v2' when releasing an older line from its maintenance branch."
+        required: true
+        default: latest
+        type: string
 
 concurrency:
   group: npm-release
@@ -15,8 +21,6 @@ jobs:
       contents: read
       id-token: write
     steps:
-      - name: Require main
-        run: test "$GITHUB_REF_NAME" = main
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
         with:
           persist-credentials: false
@@ -25,7 +29,34 @@ jobs:
           node-version: 24
           registry-url: https://registry.npmjs.org
           package-manager-cache: false
+      - name: Guard dist-tag
+        env:
+          DIST_TAG: ${{ inputs.dist-tag }}
+        run: |
+          set -euo pipefail
+          name=$(node -p "require('./package.json').name")
+          version=$(node -p "require('./package.json').version")
+          published=$(npm view "$name" dist-tags.latest 2>/dev/null || echo "")
+
+          {
+            echo "| Field | Value |"
+            echo "|---|---|"
+            echo "| Ref | \`$GITHUB_REF_NAME\` |"
+            echo "| Package | \`$name@$version\` |"
+            echo "| dist-tag | \`$DIST_TAG\` |"
+            echo "| Current \`latest\` | \`${published:-none}\` |"
+          } >> "$GITHUB_STEP_SUMMARY"
+
+          # Releases may now run from any branch, so guard the one mistake that
+          # enables: pointing `latest` at an older major line.
+          if [ "$DIST_TAG" = "latest" ] && [ -n "$published" ]; then
+            if [ "${version%%.*}" -lt "${published%%.*}" ]; then
+              echo "Refusing to move 'latest' from $published back to $version." >&2
+              echo "Re-run with a maintenance dist-tag such as 'v${version%%.*}'." >&2
+              exit 1
+            fi
+          fi
       - run: npm install --global npm@11.19.0
       - run: corepack yarn install --immutable
       - run: corepack yarn build
-      - run: npm publish --access public
+      - run: npm publish --access public --tag "${{ inputs.dist-tag }}"

--- a/README.md
+++ b/README.md
@@ -31,7 +31,7 @@ yarn install
 This implementation depends on the following libraries:
 
 - [**@huggingface/transformers**](https://github.com/huggingface/transformers.js)
-- [**js-tiktoken**](https://www.npmjs.com/package/js-tiktoken)
+- [**@huggingface/tokenizers**](https://github.com/huggingface/tokenizers.js)
 
 Especially, the `@huggingface/transformers` library utilizes various computational optimizations to achieve high performance. Please consult if the running environment supports the minimum requirements from these libraries.
 
@@ -42,7 +42,7 @@ You can use the library by downloading the library from [npm](https://www.npmjs.
 First, install the dependencies:
 
 ```sh
-npm install @huggingface/transformers js-tiktoken
+npm install @huggingface/transformers @huggingface/tokenizers
 ```
 
 Then, install the library:
@@ -100,6 +100,38 @@ You can choose between models based on your needs.
 [Learn More](https://llmlingua.com/llmlingua2.html#:~:text=our%20classification%20model.-,Performance,-We%20evaluate%20LLMLingua) about the performance of each model (actual performance may vary).
 
 The model files will be downloaded automatically by default.
+
+## Token Counting
+
+Compression is budgeted in the tokens of the LLM you send the compressed prompt
+to, not in the tokens of the classifier model above. You therefore supply a
+`countTokens` function alongside the model.
+
+The easiest way is `loadTokenCounter`, which downloads a tokenizer from the
+Hugging Face Hub:
+
+```ts
+const countTokens = await LLMLingua2.loadTokenCounter("Xenova/gpt-4o");
+```
+
+Any Hub tokenizer works, so the budget can match a non-GPT target LLM. For
+OpenAI-compatible counting:
+
+| Hub model | tiktoken encoding | Note |
+|-----------|-------------------|------|
+| `Xenova/gpt-4o` | `o200k_base` | What this library has always used |
+| `Xenova/gpt-3.5-turbo` | `cl100k_base` | What the original LLMLingua counts with |
+
+`countTokens` is just `(text: string) => number`, so you can supply your own
+instead — including one backed by a tokenizer you already have loaded:
+
+```ts
+const countTokens = LLMLingua2.createTokenCounter(myHuggingFaceTokenizer);
+```
+
+> The previous `oaiTokenizer` option still works and still accepts a
+> `js-tiktoken` `Tiktoken`, but it is deprecated in favour of `countTokens` and
+> will be removed in the next major release.
 
 ## [API Reference](https://llmlingua-2-js-typedoc.vercel.app/modules/LLMLingua2.html)
 

--- a/examples/react-vite-webgpu/package.json
+++ b/examples/react-vite-webgpu/package.json
@@ -10,7 +10,7 @@
     "preview": "vite preview"
   },
   "dependencies": {
-    "@atjsh/llmlingua-2": "^3.0.0",
+    "@atjsh/llmlingua-2": "^3.1.0",
     "@huggingface/tokenizers": "^0.1.3",
     "@huggingface/transformers": "^4.2.0",
     "@radix-ui/react-checkbox": "^1.3.2",

--- a/examples/react-vite-webgpu/package.json
+++ b/examples/react-vite-webgpu/package.json
@@ -11,6 +11,7 @@
   },
   "dependencies": {
     "@atjsh/llmlingua-2": "^3.0.0",
+    "@huggingface/tokenizers": "^0.1.3",
     "@huggingface/transformers": "^4.2.0",
     "@radix-ui/react-checkbox": "^1.3.2",
     "@radix-ui/react-collapsible": "^1.1.11",
@@ -27,7 +28,6 @@
     "cmdk": "^1.1.1",
     "comlink": "^4.4.2",
     "glob-to-regexp": "^0.4.1",
-    "js-tiktoken": "^1.0.20",
     "lucide-react": "^0.515.0",
     "react": "^19.1.0",
     "react-dom": "^19.1.0",

--- a/examples/react-vite-webgpu/src/lib/core/compressor.ts
+++ b/examples/react-vite-webgpu/src/lib/core/compressor.ts
@@ -8,14 +8,19 @@ import {
   BertForTokenClassification,
   PreTrainedModel,
 } from "@huggingface/transformers";
-import { Tiktoken } from "js-tiktoken/lite";
-import o200k_base from "js-tiktoken/ranks/o200k_base";
 
 import { MobileBertForTokenClassification } from "@/lib/transformers-js/mobileBertForTokenClassification";
 
-const oaiTokenizer = new Tiktoken(o200k_base);
 type TransformersJSConfig =
   LLMLingua2.FactoryOptions["transformerJSConfig"];
+
+// "Xenova/gpt-4o" is tiktoken's o200k_base. The tokenizer files are fetched once
+// and reused across model switches.
+let countTokensPromise: Promise<LLMLingua2.CountTokensFunction> | undefined;
+function getCountTokens(): Promise<LLMLingua2.CountTokensFunction> {
+  countTokensPromise ??= LLMLingua2.loadTokenCounter("Xenova/gpt-4o");
+  return countTokensPromise;
+}
 
 export const LLMLingua2CompressorModelName = {
   TINYBERT: "TINYBERT",
@@ -158,10 +163,12 @@ async function LLMLingua2CompressorFactory(options: {
     dtype: providedTransformersJSConfig.modelDataType,
   };
 
+  const countTokens = await getCountTokens();
+
   if (model.factory) {
     const { promptCompressor } = await model.factory(model.modelName, {
       transformerJSConfig: transformersJSConfig,
-      oaiTokenizer,
+      countTokens,
       modelSpecificOptions: model.pretrainedModelOptions,
     });
 
@@ -196,7 +203,7 @@ async function LLMLingua2CompressorFactory(options: {
       tokenizer,
       model.tokenUtils.getPureTokens,
       model.tokenUtils.isBeginOfNewWord,
-      oaiTokenizer,
+      countTokens,
       {
         max_batch_size: model.maxBatchSize,
         max_force_token: model.maxForceTokens,

--- a/package.json
+++ b/package.json
@@ -27,6 +27,7 @@
     "es-toolkit": "^1.38.0"
   },
   "devDependencies": {
+    "@huggingface/tokenizers": "^0.1.3",
     "@huggingface/transformers": "^4.2.0",
     "@types/node": "^22.15.18",
     "js-tiktoken": "^1.0.20",
@@ -35,8 +36,13 @@
     "typescript": "^5.8.3"
   },
   "peerDependencies": {
-    "@huggingface/transformers": "^4.2.0",
-    "js-tiktoken": "*"
+    "@huggingface/tokenizers": "^0.1.3",
+    "@huggingface/transformers": "^4.2.0"
+  },
+  "peerDependenciesMeta": {
+    "@huggingface/tokenizers": {
+      "optional": true
+    }
   },
   "keywords": [
     "llmlingua",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@atjsh/llmlingua-2",
-  "version": "3.0.0",
+  "version": "3.1.0",
   "packageManager": "yarn@4.9.1",
   "description": "JavaScript/TypeScript Implementation of LLMLingua-2",
   "license": "MIT",

--- a/src/e2e/factory/bert.ts
+++ b/src/e2e/factory/bert.ts
@@ -1,20 +1,17 @@
 // SPDX-License-Identifier: MIT
 
-import { Tiktoken } from "js-tiktoken/lite";
-import o200k_base from "js-tiktoken/ranks/o200k_base";
-
 import { LLMLingua2 } from "../../index.js";
 import { EXAMPLES } from "../long-texts.js";
 
 const modelName = "Arcoldd/llmlingua4j-bert-base-onnx";
-const oai_tokenizer = new Tiktoken(o200k_base);
+const countTokens = await LLMLingua2.loadTokenCounter("Xenova/gpt-4o");
 
 const { promptCompressor } = await LLMLingua2.WithBERTMultilingual(modelName, {
   transformerJSConfig: {
     device: "auto",
     dtype: "fp32",
   },
-  oaiTokenizer: oai_tokenizer,
+  countTokens,
   modelSpecificOptions: {
     subfolder: "",
   },

--- a/src/e2e/factory/xlm-roberta.ts
+++ b/src/e2e/factory/xlm-roberta.ts
@@ -1,20 +1,17 @@
 // SPDX-License-Identifier: MIT
 
-import { Tiktoken } from "js-tiktoken/lite";
-import o200k_base from "js-tiktoken/ranks/o200k_base";
-
 import { LLMLingua2 } from "../../index.js";
 import { EXAMPLES } from "../long-texts.js";
 
 const modelName = "atjsh/llmlingua-2-js-xlm-roberta-large-meetingbank";
-const oai_tokenizer = new Tiktoken(o200k_base);
+const countTokens = await LLMLingua2.loadTokenCounter("Xenova/gpt-4o");
 
 const { promptCompressor } = await LLMLingua2.WithXLMRoBERTa(modelName, {
   transformerJSConfig: {
     device: "auto",
     dtype: "fp32",
   },
-  oaiTokenizer: oai_tokenizer,
+  countTokens,
   modelSpecificOptions: {
     use_external_data_format: true,
   },

--- a/src/e2e/token-counter-parity.ts
+++ b/src/e2e/token-counter-parity.ts
@@ -1,0 +1,64 @@
+// SPDX-License-Identifier: MIT
+
+/**
+ * Migration harness for GH-33: proves that counting with `@huggingface/tokenizers`
+ * (`Xenova/gpt-4o`) matches counting with `js-tiktoken` (`o200k_base`).
+ *
+ * The compression threshold is a percentile over per-word token counts, so any
+ * divergence here silently changes compressed output. Run this before releasing:
+ *
+ *     node dist/e2e/token-counter-parity.js
+ *
+ * `js-tiktoken` is a dev-only dependency kept solely for this comparison and can
+ * be dropped once parity is confirmed.
+ */
+
+import { Tiktoken } from "js-tiktoken/lite";
+import o200k_base from "js-tiktoken/ranks/o200k_base";
+
+import { LLMLingua2 } from "../index.js";
+import { EXAMPLES } from "./long-texts.js";
+
+const tiktoken = new Tiktoken(o200k_base);
+const countWithTiktoken = (text: string) => tiktoken.encode(text).length;
+const countWithHuggingFace = await LLMLingua2.loadTokenCounter("Xenova/gpt-4o");
+
+let checked = 0;
+const mismatches: { text: string; tiktoken: number; huggingface: number }[] = [];
+
+function compare(text: string): void {
+  checked++;
+  const expected = countWithTiktoken(text);
+  const actual = countWithHuggingFace(text);
+  if (expected !== actual) {
+    mismatches.push({ text, tiktoken: expected, huggingface: actual });
+  }
+}
+
+for (const example of EXAMPLES) {
+  // Whole contexts: what sizes a `targetToken` budget.
+  compare(example);
+
+  // Individual words: what the per-word probability weighting actually feeds,
+  // and therefore what decides the compression threshold.
+  for (const word of example.split(/\s+/)) {
+    if (word.length > 0) {
+      compare(word);
+    }
+  }
+}
+
+console.log(`Compared ${checked.toLocaleString()} strings.`);
+
+if (mismatches.length > 0) {
+  console.error(`\n${mismatches.length.toLocaleString()} mismatch(es):`);
+  for (const { text, tiktoken: expected, huggingface: actual } of mismatches) {
+    const preview = text.length > 80 ? `${text.slice(0, 80)}…` : text;
+    console.error(
+      `  js-tiktoken=${expected} huggingface=${actual} ${JSON.stringify(preview)}`
+    );
+  }
+  process.exit(1);
+}
+
+console.log("Token counts match. Safe to drop js-tiktoken.");

--- a/src/lib/llmlingua-2/factory.ts
+++ b/src/lib/llmlingua-2/factory.ts
@@ -17,7 +17,6 @@ import {
   type PreTrainedModel,
   type PreTrainedTokenizer,
 } from "@huggingface/transformers";
-import type { Tiktoken } from "js-tiktoken";
 
 import { PromptCompressorLLMLingua2 } from "./prompt-compressor.js";
 import {
@@ -25,11 +24,26 @@ import {
   get_pure_tokens_xlm_roberta_large,
   is_begin_of_new_word_bert_base_multilingual_cased,
   is_begin_of_new_word_xlm_roberta_large,
+  type CountTokensFunction,
   type Logger,
+  type TokenCountingTokenizer,
 } from "./utils.js";
 
 type TransformersJSConfig = PretrainedConfig["transformers.js_config"];
 const silentLogger: Logger = () => undefined;
+
+function selectTokenCounter(
+  options: LLMLingua2FactoryOptions
+): CountTokensFunction | TokenCountingTokenizer {
+  const counter = options.countTokens ?? options.oaiTokenizer;
+  if (!counter) {
+    throw new TypeError(
+      "LLMLingua2 factory requires a token counter: pass `countTokens` (see `loadTokenCounter`). " +
+        "The deprecated `oaiTokenizer` option is also accepted."
+    );
+  }
+  return counter;
+}
 
 async function prepareDependencies(
   modelName: string,
@@ -89,9 +103,22 @@ export interface LLMLingua2FactoryOptions {
   transformerJSConfig: TransformersJSConfig;
 
   /**
-   * The tokenizer to use calculating the compression rate.
+   * Counts tokens in the tokenizer of the LLM the compressed prompt is destined
+   * for, which is what sizes the compression budget.
+   *
+   * Takes precedence over {@link LLMLingua2FactoryOptions.oaiTokenizer}. Build
+   * one with `loadTokenCounter`, or supply any `(text: string) => number`.
    */
-  oaiTokenizer: Tiktoken;
+  countTokens?: CountTokensFunction;
+
+  /**
+   * The tokenizer to use calculating the compression rate.
+   *
+   * @deprecated Pass {@link LLMLingua2FactoryOptions.countTokens} instead. This
+   *   option is retained so existing `js-tiktoken` callers keep working, and
+   *   will be removed in the next major release.
+   */
+  oaiTokenizer?: TokenCountingTokenizer;
 
   /**
    * Optional pretrained configuration.
@@ -149,15 +176,15 @@ export interface LLMLingua2FactoryReturn {
  *
  * @category Factory
  * 
- * @example 
+ * @example
  * ```ts
 import { LLMLingua2 } from "@atjsh/llmlingua-2";
 
-import { Tiktoken } from "js-tiktoken/lite";
-import o200k_base from "js-tiktoken/ranks/o200k_base";
-
 const modelName = "atjsh/llmlingua-2-js-xlm-roberta-large-meetingbank";
-const oai_tokenizer = new Tiktoken(o200k_base);
+
+// "Xenova/gpt-4o" is tiktoken's o200k_base. Use "Xenova/gpt-3.5-turbo" for
+// cl100k_base, which is what the original LLMLingua counts with.
+const countTokens = await LLMLingua2.loadTokenCounter("Xenova/gpt-4o");
 
 const { promptCompressor } = await LLMLingua2.WithXLMRoBERTa(modelName,
   {
@@ -165,7 +192,7 @@ const { promptCompressor } = await LLMLingua2.WithXLMRoBERTa(modelName,
       device: "cpu",
       dtype: "fp32",
     },
-    oaiTokenizer: oai_tokenizer,
+    countTokens,
     modelSpecificOptions: {
       use_external_data_format: { "model.onnx": 1 },
     },
@@ -186,12 +213,12 @@ export async function WithXLMRoBERTa(
 ): Promise<LLMLingua2FactoryReturn> {
   const {
     transformerJSConfig,
-    oaiTokenizer,
     pretrainedConfig,
     pretrainedTokenizerOptions,
     modelSpecificOptions,
     logger = silentLogger,
   } = options;
+  const countTokens = selectTokenCounter(options);
 
   const { model, tokenizer, config } = await prepareDependencies(
     modelName,
@@ -207,7 +234,7 @@ export async function WithXLMRoBERTa(
     tokenizer,
     get_pure_tokens_xlm_roberta_large,
     is_begin_of_new_word_xlm_roberta_large,
-    oaiTokenizer,
+    countTokens,
     undefined,
     logger
   );
@@ -228,15 +255,15 @@ export async function WithXLMRoBERTa(
  *
  * @category Factory
  * 
- * @example 
+ * @example
  * ```ts
 import { LLMLingua2 } from "@atjsh/llmlingua-2";
 
-import { Tiktoken } from "js-tiktoken/lite";
-import o200k_base from "js-tiktoken/ranks/o200k_base";
-
 const modelName = "Arcoldd/llmlingua4j-bert-base-onnx";
-const oai_tokenizer = new Tiktoken(o200k_base);
+
+// "Xenova/gpt-4o" is tiktoken's o200k_base. Use "Xenova/gpt-3.5-turbo" for
+// cl100k_base, which is what the original LLMLingua counts with.
+const countTokens = await LLMLingua2.loadTokenCounter("Xenova/gpt-4o");
 
 const { promptCompressor } = await LLMLingua2.WithBERTMultilingual(modelName,
   {
@@ -244,7 +271,7 @@ const { promptCompressor } = await LLMLingua2.WithBERTMultilingual(modelName,
       device: "cpu",
       dtype: "fp32",
     },
-    oaiTokenizer: oai_tokenizer,
+    countTokens,
     modelSpecificOptions: {
       subfolder: "",
     },
@@ -265,12 +292,12 @@ export async function WithBERTMultilingual(
 ): Promise<LLMLingua2FactoryReturn> {
   const {
     transformerJSConfig,
-    oaiTokenizer,
     pretrainedConfig,
     pretrainedTokenizerOptions,
     modelSpecificOptions,
     logger = silentLogger,
   } = options;
+  const countTokens = selectTokenCounter(options);
 
   const { model, tokenizer, config } = await prepareDependencies(
     modelName,
@@ -286,7 +313,7 @@ export async function WithBERTMultilingual(
     tokenizer,
     get_pure_tokens_bert_base_multilingual_cased,
     is_begin_of_new_word_bert_base_multilingual_cased,
-    oaiTokenizer,
+    countTokens,
     undefined,
     logger
   );

--- a/src/lib/llmlingua-2/index.ts
+++ b/src/lib/llmlingua-2/index.ts
@@ -6,13 +6,20 @@ export {
   CompressPromptOptionsSnakeCase,
 } from "./prompt-compressor.js";
 export {
+  CountTokensFunction,
   get_pure_tokens_bert_base_multilingual_cased,
   get_pure_tokens_xlm_roberta_large,
   GetPureTokenFunction,
   is_begin_of_new_word_bert_base_multilingual_cased,
   is_begin_of_new_word_xlm_roberta_large,
   IsBeginOfNewWordFunction,
+  TokenCountingTokenizer,
 } from "./utils.js";
+export {
+  createTokenCounter,
+  loadTokenCounter,
+  LoadTokenCounterOptions,
+} from "./token-counter.js";
 export {
   WithXLMRoBERTa,
   WithBERTMultilingual,

--- a/src/lib/llmlingua-2/prompt-compressor.ts
+++ b/src/lib/llmlingua-2/prompt-compressor.ts
@@ -12,13 +12,15 @@ import {
   Tensor,
 } from "@huggingface/transformers";
 import { chunk } from "es-toolkit/array";
-import { Tiktoken } from "js-tiktoken/lite";
 
+import { resolveTokenCounter } from "./token-counter.js";
 import {
+  CountTokensFunction,
   GetPureTokenFunction,
   IsBeginOfNewWordFunction,
   Logger,
   percentile,
+  TokenCountingTokenizer,
 } from "./utils.js";
 
 type TokenSpan = readonly [start: number, end: number];
@@ -210,6 +212,11 @@ interface CompressSingleContextOptions {
 export class PromptCompressorLLMLingua2 {
   private specialTokenIds: Set<number>;
 
+  /**
+   * Normalized form of the `countTokens` constructor argument.
+   */
+  private readonly countTokens: CountTokensFunction;
+
   constructor(
     /**
      * The pre-trained model to use for compression.
@@ -234,9 +241,14 @@ export class PromptCompressorLLMLingua2 {
     private readonly isBeginOfNewWord: IsBeginOfNewWordFunction,
 
     /**
-     * The tokenizer to use calculating the compression rate.
+     * Counts tokens in the tokenizer of the LLM this prompt is destined for,
+     * which is what sizes the compression budget.
+     *
+     * Passing a tokenizer object is deprecated; pass a
+     * {@link CountTokensFunction} such as the one returned by
+     * `loadTokenCounter` instead.
      */
-    private readonly oaiTokenizer: Tiktoken,
+    countTokens: CountTokensFunction | TokenCountingTokenizer,
 
     /**
      * Configuration for LLMLingua2.
@@ -266,6 +278,7 @@ export class PromptCompressorLLMLingua2 {
      */
     private readonly logger: Logger = () => {}
   ) {
+    this.countTokens = resolveTokenCounter(countTokens);
     this.specialTokenIds = new Set(this.tokenizer.all_special_ids);
   }
 
@@ -337,7 +350,7 @@ export class PromptCompressorLLMLingua2 {
       );
     }
 
-    const n_original_token = this.oaiTokenizer.encode(context).length;
+    const n_original_token = this.countTokens(context);
 
     this.logger(
       "original token length: appx. ",
@@ -1000,7 +1013,7 @@ export class PromptCompressorLLMLingua2 {
 
           const new_token_probs: number[] = [];
           for (let i = 0; i < words.length; i++) {
-            const tokenCount = this.oaiTokenizer.encode(words[i]).length;
+            const tokenCount = this.countTokens(words[i]);
             new_token_probs.push(...Array(tokenCount).fill(word_probs[i]));
           }
 

--- a/src/lib/llmlingua-2/token-counter.ts
+++ b/src/lib/llmlingua-2/token-counter.ts
@@ -1,0 +1,121 @@
+// SPDX-License-Identifier: MIT
+
+/**
+ * @categoryDescription Token Counting
+ * Helpers for supplying the token counter that sizes the compression budget.
+ */
+
+import type { Tokenizer } from "@huggingface/tokenizers";
+
+import type { CountTokensFunction, TokenCountingTokenizer } from "./utils.js";
+
+const DEFAULT_ENDPOINT = "https://huggingface.co";
+const DEFAULT_REVISION = "main";
+
+/**
+ * Adapts a `@huggingface/tokenizers` `Tokenizer` into a {@link CountTokensFunction}.
+ *
+ * Special tokens are excluded so the count matches what the target LLM bills for
+ * the text itself. Tokenizers that append a BOS/CLS token during post-processing
+ * would otherwise inflate every count by a constant.
+ *
+ * @category Token Counting
+ *
+ * @example
+ * ```ts
+import { LLMLingua2 } from "@atjsh/llmlingua-2";
+import { Tokenizer } from "@huggingface/tokenizers";
+
+const tokenizer = new Tokenizer(tokenizerJson, tokenizerConfigJson);
+const countTokens = LLMLingua2.createTokenCounter(tokenizer);
+```
+ */
+export function createTokenCounter(tokenizer: Tokenizer): CountTokensFunction {
+  return (text) =>
+    tokenizer.encode(text, { add_special_tokens: false }).ids.length;
+}
+
+/**
+ * Options for {@link loadTokenCounter}.
+ *
+ * @category Token Counting
+ */
+export interface LoadTokenCounterOptions {
+  /**
+   * Git revision to read the tokenizer files from. Defaults to `"main"`.
+   */
+  revision?: string;
+
+  /**
+   * Base URL of the Hugging Face Hub, for mirrors or self-hosted endpoints.
+   * Defaults to `"https://huggingface.co"`.
+   */
+  endpoint?: string;
+}
+
+async function fetchJson(url: string, modelId: string): Promise<unknown> {
+  const response = await fetch(url);
+  if (!response.ok) {
+    throw new Error(
+      `Failed to load tokenizer files for "${modelId}": ${response.status} ${response.statusText} (${url})`
+    );
+  }
+  return await response.json();
+}
+
+/**
+ * Downloads `tokenizer.json` and `tokenizer_config.json` for a Hugging Face Hub
+ * model and returns a {@link CountTokensFunction} built from them.
+ *
+ * Pick the model to match the LLM the compressed prompt is sent to. Any Hub
+ * tokenizer works; for OpenAI-compatible counting:
+ *
+ * | Model | tiktoken encoding |
+ * |---|---|
+ * | `"Xenova/gpt-4o"` | `o200k_base` |
+ * | `"Xenova/gpt-3.5-turbo"` | `cl100k_base`, which is what the original LLMLingua counts with |
+ *
+ * Requires the optional peer dependency `@huggingface/tokenizers`, which is
+ * imported dynamically so callers who supply their own counter never load it.
+ *
+ * @category Token Counting
+ *
+ * @example
+ * ```ts
+import { LLMLingua2 } from "@atjsh/llmlingua-2";
+
+const countTokens = await LLMLingua2.loadTokenCounter("Xenova/gpt-4o");
+```
+ */
+export async function loadTokenCounter(
+  modelId: string,
+  options: LoadTokenCounterOptions = {}
+): Promise<CountTokensFunction> {
+  const { revision = DEFAULT_REVISION, endpoint = DEFAULT_ENDPOINT } = options;
+
+  const { Tokenizer } = await import("@huggingface/tokenizers");
+
+  const base = `${endpoint.replace(/\/+$/, "")}/${modelId}/resolve/${revision}`;
+  const [tokenizerJson, tokenizerConfigJson] = await Promise.all([
+    fetchJson(`${base}/tokenizer.json`, modelId),
+    fetchJson(`${base}/tokenizer_config.json`, modelId),
+  ]);
+
+  return createTokenCounter(
+    new Tokenizer(tokenizerJson as object, tokenizerConfigJson as object)
+  );
+}
+
+/**
+ * Normalizes either accepted form of a token counter into a
+ * {@link CountTokensFunction}.
+ *
+ * @internal
+ */
+export function resolveTokenCounter(
+  source: CountTokensFunction | TokenCountingTokenizer
+): CountTokensFunction {
+  return typeof source === "function"
+    ? source
+    : (text) => source.encode(text).length;
+}

--- a/src/lib/llmlingua-2/utils.ts
+++ b/src/lib/llmlingua-2/utils.ts
@@ -48,6 +48,33 @@ export const get_pure_tokens_bert_base_multilingual_cased: GetPureTokenFunction 
   };
 
 /**
+ * Counts how many tokens `text` occupies in the tokenizer of the LLM the compressed
+ * prompt is destined for.
+ *
+ * This is used only to size the compression budget — it never feeds the token
+ * classification model. It corresponds to `get_token_length(..., use_oai_tokenizer=True)`
+ * of the original LLMLingua implementation.
+ *
+ * @see [Original Implementation](https://github.com/microsoft/LLMLingua/blob/e0e9d99beb94098bbd924aa53c2c112eac41c758/llmlingua/prompt_compressor.py#L975)
+ *
+ * @category Adaptors
+ */
+export type CountTokensFunction = (text: string) => number;
+
+/**
+ * A tokenizer object whose `encode` returns an array-like of tokens, such as a
+ * `js-tiktoken` `Tiktoken`. The shape is structural on purpose: this package does
+ * not depend on any tokenizer library.
+ *
+ * @deprecated Supply a {@link CountTokensFunction} instead.
+ *
+ * @category Adaptors
+ */
+export interface TokenCountingTokenizer {
+  encode(text: string): { length: number };
+}
+
+/**
  * Implementation on `is_begin_of_new_word` function of original LLMLingua implementation.
  * @see [Original Implementation](https://github.com/microsoft/LLMLingua/blob/e4e172afb42d8ae3c0b6cb271a3f5d6a812846a0/llmlingua/utils.py#L81)
  *

--- a/yarn.lock
+++ b/yarn.lock
@@ -9,6 +9,7 @@ __metadata:
   version: 0.0.0-use.local
   resolution: "@atjsh/llmlingua-2@workspace:."
   dependencies:
+    "@huggingface/tokenizers": "npm:^0.1.3"
     "@huggingface/transformers": "npm:^4.2.0"
     "@types/node": "npm:^22.15.18"
     es-toolkit: "npm:^1.38.0"
@@ -17,8 +18,11 @@ __metadata:
     typedoc: "npm:^0.28.4"
     typescript: "npm:^5.8.3"
   peerDependencies:
+    "@huggingface/tokenizers": ^0.1.3
     "@huggingface/transformers": ^4.2.0
-    js-tiktoken: "*"
+  peerDependenciesMeta:
+    "@huggingface/tokenizers":
+      optional: true
   languageName: unknown
   linkType: soft
 


### PR DESCRIPTION
Closes #33.

## What this changes

The library runs two tokenizers for unrelated jobs. The `AutoTokenizer` from `@huggingface/transformers` is the real pipeline — text → `input_ids` → ONNX token classifier → decode — and is untouched here. The other one, injected as `oaiTokenizer`, is pure accounting: it counts how many tokens the **target LLM** would bill so the compression budget can be sized. It was only ever used for `.encode(x).length`, at two call sites.

That second one moves from `js-tiktoken` to [`@huggingface/tokenizers`](https://github.com/huggingface/tokenizers.js).

Worth noting: **`@huggingface/transformers@4.2.0` already depends on `@huggingface/tokenizers@^0.1.3`**, so on the 3.x line this adds no transitive weight at all — it replaces a second BPE engine plus a bundled ~2 MB rank table with a `tokenizer.json` fetched and cached like the model already is.

## API

The injected value is now a **counting function**, matching the repo's existing `GetPureTokenFunction` / `IsBeginOfNewWordFunction` adaptor idiom. The library's type surface therefore depends on no tokenizer package at all:

```ts
export type CountTokensFunction = (text: string) => number;
```

New exports:

| Export | Purpose |
|---|---|
| `loadTokenCounter(modelId, options?)` | Fetches `tokenizer.json` + `tokenizer_config.json` from the Hub and returns a counter |
| `createTokenCounter(tokenizer)` | Adapts an already-loaded `@huggingface/tokenizers` `Tokenizer` |
| `CountTokensFunction`, `TokenCountingTokenizer`, `LoadTokenCounterOptions` | Types |

```ts
const countTokens = await LLMLingua2.loadTokenCounter("Xenova/gpt-4o");

const { promptCompressor } = await LLMLingua2.WithXLMRoBERTa(modelName, {
  transformerJSConfig: { device: "cpu", dtype: "fp32" },
  countTokens,
});
```

The encoding is the caller's choice, since any Hub tokenizer works — the budget can now match a non-GPT target LLM:

| Hub model | tiktoken encoding | Note |
|---|---|---|
| `Xenova/gpt-4o` | `o200k_base` | What this library has always used |
| `Xenova/gpt-3.5-turbo` | `cl100k_base` | What `microsoft/LLMLingua` counts with (`tiktoken.encoding_for_model("gpt-3.5-turbo")`) |

Examples, e2e scripts and the demo stay on `gpt-4o`, so **compression output is unchanged**.

## Backward compatible — this is a minor, not a major

`oaiTokenizer` still works and still accepts a `js-tiktoken` `Tiktoken`. It is retyped **structurally** as `{ encode(text: string): { length: number } }` and marked `@deprecated`. A `Tiktoken` satisfies that shape (its `encode` returns `number[]`), so existing caller code compiles and runs untouched while this repo imports nothing from `js-tiktoken`. That is what lets the dependency go away in a minor release.

Removing `js-tiktoken` from `peerDependencies` is likewise not breaking — consumers keep their installed copy.

`@huggingface/tokenizers` is declared as an **optional** peer dependency and imported dynamically inside `loadTokenCounter`, so callers who supply their own `CountTokensFunction` never resolve it.

## Fidelity to the original implementation

Both call sites keep upstream semantics:

- `n_original_token` mirrors `get_token_length(context[i], use_oai_tokenizer=True)` — converts a `target_token` budget into a rate.
- The per-word site mirrors `num_token = len(self.oai_tokenizer.encode(word))` — replicates each word's keep-probability once per target-LLM token so the percentile threshold is denominated in the billed tokenizer, not the classifier's. This is the site that decides output.

One detail that matters: `Tokenizer.encode` defaults `add_special_tokens` to `true`, so `createTokenCounter` passes `false`. Harmless for GPT `tokenizer.json` files, but wrong for Llama/BERT-style ones that prepend BOS/CLS.

## Releases

Two lines, one branch each, mirroring the #24 → #27/#32 precedent:

| Branch | Version | Status |
|---|---|---|
| `GH-33-v3` (this PR) | **3.1.0** | → `main`, publish `latest` |
| [`GH-33-v2`](https://github.com/atjsh/llmlingua-2-js/tree/GH-33-v2) | **2.1.0** | maintenance branch, publish `--tag v2`, **not merged** |

`GH-33-v2` must not merge into `main` — it would revert the version and the `@huggingface/transformers` peer range back to `^3.5.2 || ^4.0.0`. It carries the same change adapted to the 2.x compressor, which has only one of the two call sites (2.x derives `n_original_token` from the model tokenizer, not tiktoken; left as-is).

Because that release cannot come from `main`, `publish.yml` drops its `test "$GITHUB_REF_NAME" = main` gate. Removing that gate makes one mistake possible — pointing `latest` at an older major — so the workflow gains a required `dist-tag` input and refuses `latest` when the version being published has a lower major than the currently published `latest`. Ref, version and tag go to the job summary.

**Nothing is published by this PR.** Dispatch **Publish** yourself: from `main` with `dist-tag: latest` after merge, and from `GH-33-v2` with `dist-tag: v2`.

## Verification

Done:

- `tsc` clean on both branches (3.x against `@huggingface/transformers` 4.2.0, 2.x against 3.8.1).
- `yarn install --immutable` resolution passes on both — lockfiles are consistent with `package.json`.
- Deprecated path type-checks: a `FactoryFactoryOptions` carrying `oaiTokenizer: new Tiktoken(o200k_base)` still compiles.
- `resolveTokenCounter` returns identical counts for a `Tiktoken` object and an equivalent function (16 = 16 = 16 on a sample string).
- `createTokenCounter` verified to pass `add_special_tokens: false`.
- Emitted `token-counter.js` has no static `@huggingface/tokenizers` import; only the dynamic one.
- `npm pack --dry-run`: 27 files, no `e2e` in the tarball.

**Not done — needs a machine with Hub access.** `huggingface.co` is blocked by this environment's network egress proxy, so neither the tokenizer fetch nor the ONNX model download could run:

- `node dist/e2e/token-counter-parity.js` — added in this PR. Compares `js-tiktoken` (`o200k_base`) against `loadTokenCounter("Xenova/gpt-4o")` over every entry in the multilingual `EXAMPLES` fixture **and** over each entry's individual words, since single words are what the threshold-deciding call site actually feeds. Exits non-zero on any mismatch. **This is the gate that proves compression output is unchanged — please run it before releasing.**
- The two `dist/e2e/factory/*.js` end-to-end runs.
- A demo build (its `@atjsh/llmlingua-2` dep now points at the unpublished `^3.1.0`).

`js-tiktoken` is kept as a **dev-only** dependency solely for that parity harness — it is gone from `peerDependencies`, the README, all of `src/lib`, and the demo, so nothing a consumer installs or bundles includes it. Once parity is confirmed, deleting the harness and the devDependency is a one-line follow-up; happy to do that instead if you'd rather it go now.

---
_Generated by [Claude Code](https://claude.ai/code/session_01VBGbiVSbficFY6dyV4kxGF)_

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added Hugging Face tokenizer support for token counting.
  - Added utilities to load tokenizers from configurable model sources.
  - Added flexible token-counting callbacks for compression workflows.
  - Exported new token-counting APIs and types.
- **Bug Fixes**
  - Improved token-count consistency through parity validation.
  - Added validation when no token counter is configured.
- **Documentation**
  - Updated installation and usage guidance for Hugging Face tokenizers.
  - Documented token counting, custom counters, and deprecated tokenizer options.
- **Chores**
  - Updated the package to version 3.1.0 and refreshed example dependencies.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->